### PR TITLE
Change test environment for Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {},
   "jest": {
+    "testEnvironment": "node",
     "testRegex": "\\.js$"
   },
   "license": "MIT"


### PR DESCRIPTION
This change should improve performance of tests executed by Jest runner. It addresses my comment from Medium: https://medium.com/@gziolo/jest-uses-jsdom-env-as-default-one-c3e1571d5053:

> Jest uses jsdom env as default one. Please note that you can update it to use node instead to make it faster. I would recommend adding another runner config that takes that into account. See related doc about this flag: https://facebook.github.io/jest/docs/en/configuration.html#testenvironment-string. This would better align with what Mocha or Jasmine offer out of the box.

I noticed that Jest is configured inside `package.json` so I simply updated it to change test environment. Another option is as I suggested on Medium, use 2 different configs to show differences between test environments.